### PR TITLE
[fix] #3 실제 테이블 스키마에 맞춰 SQL 프롬프트 수정

### DIFF
--- a/src/main/java/nhnad/soeun_chat/domain/chat/service/BedrockService.java
+++ b/src/main/java/nhnad/soeun_chat/domain/chat/service/BedrockService.java
@@ -29,19 +29,40 @@ public class BedrockService {
 
     private static final String SQL_SYSTEM_PROMPT = """
             당신은 AWS Athena SQL 전문가입니다. 사용자의 자연어 질문을 Athena SQL로 변환하세요.
+            반드시 순수 SQL만 반환하세요. 설명, 한글 텍스트, 마크다운 코드블록은 절대 포함하지 마세요.
 
-            테이블: se_report_db.se_ad_performance_parquet
-            컬럼: date(string), campaign_id(string), campaign_name(string),
-                  ad_group_id(string), ad_group_name(string),
-                  impressions(bigint), clicks(bigint), cost(double),
-                  conversions(bigint), conversion_value(double),
-                  platform(string, 파티션), year(string, 파티션),
-                  month(string, 파티션), day(string, 파티션)
+            [google_ad_performance 테이블]
+            - 파티션: year, month, day
+            - 주요 컬럼: camp_id, camp_name, camp_advertising_channel_type, camp_status,
+                          agroup_id, agroup_name, keyword_id, keyword_text, keyword_match_type,
+                          device, network_type, basic_date, adv_id, date, quarter, day_of_week, week
+            - 성과 컬럼(bigint): impressions, clicks, video_views, all_conversions, conversions
+            - 성과 컬럼(double): cost_micros, ctr, average_cpc, all_conversions_value,
+                                  conversions_value, value_per_conversion, cost_per_conversion,
+                                  conversions_from_interactions_rate,
+                                  video_quartile_p25_rate, video_quartile_p50_rate,
+                                  video_quartile_p75_rate, video_quartile_p100_rate
 
-            규칙:
-            - SQL 쿼리만 반환하세요. 마크다운 코드블록 없이 순수 SQL만.
-            - 파티션 컬럼(platform, year, month, day)을 WHERE 조건에 활용하세요.
-            - 날짜 범위가 없으면 최근 30일 데이터를 조회하세요.
+            [kakao_ad_performance 테이블]
+            - 파티션: year, month, day
+            - 주요 컬럼: kwd_id, kwd_name, kwd_config, kwd_url, kwd_bid_type, kwd_bid_amount,
+                          agroup_id, agroup_name, camp_id, camp_name, camp_type,
+                          biz_id, biz_name, basic_date, adv_id
+            - 성과 컬럼(bigint): imp, click, rimp, rank,
+                                  conv_cmpt_reg_1d, conv_cmpt_reg_7d,
+                                  conv_view_cart_1d, conv_view_cart_7d,
+                                  conv_purchase_1d, conv_purchase_7d,
+                                  conv_participation_1d, conv_participation_7d,
+                                  conv_signup_1d, conv_signup_7d,
+                                  conv_app_install_1d, conv_app_install_7d
+            - 성과 컬럼(double): spending, ctr, ppc, conv_purchase_p_1d, conv_purchase_p_7d
+
+            쿼리 작성 규칙:
+            - 항상 파티션 컬럼(year, month, day)을 WHERE 조건에 포함하세요.
+            - 데이터베이스명을 명시하세요: se_report_db.google_ad_performance 또는 se_report_db.kakao_ad_performance
+            - 날짜 필터가 없으면 최근 30일 기준으로 작성하세요.
+            - 두 테이블이 모두 필요하면 UNION ALL을 사용하세요.
+            - 광고 데이터 분석과 무관한 질문에는 다음 SQL만 반환하세요: SELECT 'INVALID_QUERY' AS result
             """;
 
     private static final String ANSWER_SYSTEM_PROMPT = """


### PR DESCRIPTION
## 개요
실제 Athena 테이블 스키마에 맞춰 SQL 생성 프롬프트를 수정하고, 광고 무관 질문 처리를 추가합니다.

## 작업 내용
- [x] BedrockService — SQL 시스템 프롬프트를 google_ad_performance / kakao_ad_performance 실제 스키마로 교체
- [x] BedrockService — 순수 SQL만 반환하도록 규칙 강화 (마크다운, 한글 텍스트 금지)
- [x] ChatService — INVALID_QUERY 감지 시 Athena 실행 없이 안내 메시지 스트리밍 후 종료

## 관련 이슈
closes #3

## 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 코드/주석 제거